### PR TITLE
v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes are detailed here with headings of \<Version\> - \<YYYY.MM.DD\> in reverse chronological order.
 
+## 0.1.8 - 2024.11.18
+
+### Fixed
+
+- Bindgen >= v0.70 introduced unstable library feature offset_of, causing
+Rust < 1.81.0 compilation errors.
+
 ## 0.1.7 - 2024.11.1
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libparasail-sys"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Nicolas S. Buitrago <nsb5@rice.edu>"]
 links = "parasail"
 build = "build.rs"
@@ -17,6 +17,6 @@ include = [
 ]
 
 [build-dependencies]
-bindgen = "0.70.1"
+bindgen = "0.69.5"
 pkg-config = "0.3.31"
 


### PR DESCRIPTION
fix: bindgen >= v0.70 offset_of unstable library feature for rust < 1.81.0