### PR TITLE
Update build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -119,7 +119,8 @@ fn build_parasail() {
             .args([
                 "--build",
                 &parasail_build.to_str().unwrap(),
-                "--target parasail"
+                "--target",
+                "parasail"
             ])
             .current_dir(&parasail_build)
             .status()


### PR DESCRIPTION
Thanks for making this crate.

I get a build error on Rocky9 which I traced down to the cmake argument formatting:

```
  --- stderr
  Unknown argument --target parasail
  Usage: cmake --build <dir> [options] [-- [native-options]]
  Options:
    <dir>          = Project binary directory to be built.
    -j [<jobs>] --parallel [<jobs>] = Build in parallel using
                     the given number of jobs. If <jobs> is omitted
                     the native build tool's default number is used.
                     The CMAKE_BUILD_PARALLEL_LEVEL environment variable
                     specifies a default parallel level when this option
                     is not given.
    --target <tgt> = Build <tgt> instead of default targets.
                     May only be specified once.
    --config <cfg> = For multi-configuration tools, choose <cfg>.
    --clean-first  = Build target 'clean' first, then build.
                     (To clean only, use --target 'clean'.)
    --use-stderr   = Ignored.  Behavior is default in CMake >= 3.0.
    -v --verbose   = Enable verbose output - if supported - including
                     the build commands to be executed.
    --             = Pass remaining options to the native tool.
```

This error message makes sense, as currently formatted on the main branch the arguments should be similar to the following shell command:

    cmake --build /path/to/build/dir "--target parasail"

I see that there's test coverage for the parasail source build using cmake on github actions, and the error doesn't show up there, not clear to me why. The simple change here fixes the build for my case, appreciate it if you could incorporate it.
